### PR TITLE
[refactor] 구글, 네이버, 카카오 로그인 리팩토링

### DIFF
--- a/zzimtory/App/AppDelegate.swift
+++ b/zzimtory/App/AppDelegate.swift
@@ -19,7 +19,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         FirebaseApp.configure()
-        GoogleAuthManager.shared.configure()
         KakaoSDK.initSDK(appKey: AuthClientID.nativeAppKey)
         
         let instance = NaverThirdPartyLoginConnection.getSharedInstance()

--- a/zzimtory/Helper/AuthProtocol.swift
+++ b/zzimtory/Helper/AuthProtocol.swift
@@ -18,7 +18,7 @@ protocol NativeAuthProtocol: AnyObject {
 /// 파이어베이스에서 제공하지 않는 로그인 과정 추상화
 protocol ThirdPartyAuthProtocol: AnyObject {
     func login()
-    func firbaseLogin()
+    func firebaseLogin()
     func logout()
     func disconnect()
 }

--- a/zzimtory/Helper/AuthProtocol.swift
+++ b/zzimtory/Helper/AuthProtocol.swift
@@ -10,10 +10,7 @@ import GoogleSignIn
 
 /// 파이어베이스에서 제공하는 로그인 과정 추상화
 protocol NativeAuthProtocol: AnyObject {
-    func login(
-        from viewController: UIViewController,
-        comletion: @escaping (Result<UserCredential, Error>) -> Void
-    )
+    func login(from viewController: UIViewController)
     func logout()
     func disconnect()
 }
@@ -24,22 +21,4 @@ protocol ThirdPartyAuthProtocol: AnyObject {
     func firbaseLogin()
     func logout()
     func disconnect()
-}
-
-/// 로그인 결과 표준화하는 구조체
-struct UserCredential {
-    let uid: String?
-    let email: String?
-    let nickname: String?
-    let token: String
-    
-    /// 구글 사용자 정보로부터 UserCredential 생성하는 생성자
-    init(from googleUser: GIDGoogleUser) {
-        self.uid = googleUser.userID
-        self.email = googleUser.profile?.email
-        self.nickname = googleUser.profile?.name
-        self.token = googleUser.accessToken.tokenString
-    }
-    
-    // 추후에 애플 유저 로그인도 추가
 }

--- a/zzimtory/Helper/AuthProtocol.swift
+++ b/zzimtory/Helper/AuthProtocol.swift
@@ -1,0 +1,21 @@
+//
+//  AuthProtocol.swift
+//  zzimtory
+//
+//  Created by 이명지 on 1/31/25.
+//
+
+/// 파이어베이스에서 제공하는 로그인 과정 추상화
+protocol NativeAuthProtocol: AnyObject {
+    func login()
+    func logout()
+    func disconnect()
+}
+
+/// 파이어베이스에서 제공하지 않는 로그인 과정 추상화
+protocol ThirdPartyAuthProtocol: AnyObject {
+    func login()
+    func firbaseLogin()
+    func logout()
+    func disconnect()
+}

--- a/zzimtory/Helper/AuthProtocol.swift
+++ b/zzimtory/Helper/AuthProtocol.swift
@@ -5,9 +5,15 @@
 //  Created by 이명지 on 1/31/25.
 //
 
+import UIKit
+import GoogleSignIn
+
 /// 파이어베이스에서 제공하는 로그인 과정 추상화
 protocol NativeAuthProtocol: AnyObject {
-    func login()
+    func login(
+        from viewController: UIViewController,
+        comletion: @escaping (Result<UserCredential, Error>) -> Void
+    )
     func logout()
     func disconnect()
 }
@@ -18,4 +24,22 @@ protocol ThirdPartyAuthProtocol: AnyObject {
     func firbaseLogin()
     func logout()
     func disconnect()
+}
+
+/// 로그인 결과 표준화하는 구조체
+struct UserCredential {
+    let uid: String?
+    let email: String?
+    let nickname: String?
+    let token: String
+    
+    /// 구글 사용자 정보로부터 UserCredential 생성하는 생성자
+    init(from googleUser: GIDGoogleUser) {
+        self.uid = googleUser.userID
+        self.email = googleUser.profile?.email
+        self.nickname = googleUser.profile?.name
+        self.token = googleUser.accessToken.tokenString
+    }
+    
+    // 추후에 애플 유저 로그인도 추가
 }

--- a/zzimtory/Helper/GoogleAuthManager.swift
+++ b/zzimtory/Helper/GoogleAuthManager.swift
@@ -7,42 +7,51 @@
 
 import Foundation
 import GoogleSignIn
+import FirebaseAuth
 
-final class GoogleAuthManager {
-    
-    static let shared = GoogleAuthManager()
-    
-    private init() {}
+final class GoogleAuthManager: NativeAuthProtocol {
+    private let instance = GIDSignIn.sharedInstance
     
     /// 구글 로그인 초기 설정 메서드
     func configure() {
-        GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: AuthClientID.google)
+        instance.configuration = GIDConfiguration(clientID: AuthClientID.google)
     }
     
     /// 로그인 메서드
-    func login(presenting viewController: UIViewController, completion: @escaping (Result<GIDGoogleUser, Error>) -> Void) {
-        GIDSignIn.sharedInstance.signIn(withPresenting: viewController) { signInResult, error in
+    func login(from viewController: UIViewController) {
+        instance.signIn(withPresenting: viewController) { signInResult, error in
             if let error = error {
-                completion(.failure(error))
+                print(error)
                 return
             }
             guard let user = signInResult?.user else {
-                completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "잘못된 사용자 정보입니다."])))
+                print("잘못된 사용자 정보입니다.")
                 return
             }
-            completion(.success(user))
+            guard let idToken = user.idToken?.tokenString else { return }
+            let credential = GoogleAuthProvider.credential(
+                withIDToken: idToken,
+                accessToken: user.accessToken.tokenString
+            )
+            Auth.auth().signIn(with: credential) { authResult, error in
+                if let error = error as NSError? {
+                    print("파이어베이스 인증 오류: \(error.localizedDescription)")
+                    return
+                }
+                print("파이어베이스 인증 성공")
+            }
         }
     }
     
     /// 로그아웃 메서드
     func logout() {
-        GIDSignIn.sharedInstance.signOut()
+        instance.signOut()
     }
     
     /// 계정의 구글 로그인 연동 끊는 메서드
-    func disconnect(completion: @escaping (Error?) -> Void) {
-        GIDSignIn.sharedInstance.disconnect { error in
-            completion(error)
+    func disconnect() {
+        instance.disconnect { error in
+            print("error: \(String(describing: error))")
         }
     }
 }

--- a/zzimtory/Helper/GoogleAuthManager.swift
+++ b/zzimtory/Helper/GoogleAuthManager.swift
@@ -33,7 +33,7 @@ final class GoogleAuthManager: NativeAuthProtocol {
                 withIDToken: idToken,
                 accessToken: user.accessToken.tokenString
             )
-            Auth.auth().signIn(with: credential) { authResult, error in
+            Auth.auth().signIn(with: credential) { _, error in
                 if let error = error as NSError? {
                     print("파이어베이스 인증 오류: \(error.localizedDescription)")
                     return

--- a/zzimtory/Helper/GoogleAuthManager.swift
+++ b/zzimtory/Helper/GoogleAuthManager.swift
@@ -12,8 +12,8 @@ import FirebaseAuth
 final class GoogleAuthManager: NativeAuthProtocol {
     private let instance = GIDSignIn.sharedInstance
     
-    /// 구글 로그인 초기 설정 메서드
-    func configure() {
+    init() {
+        // 구글 로그인 초기화
         instance.configuration = GIDConfiguration(clientID: AuthClientID.google)
     }
     

--- a/zzimtory/Helper/KakaoAuthManager.swift
+++ b/zzimtory/Helper/KakaoAuthManager.swift
@@ -11,7 +11,7 @@ import KakaoSDKUser
 import KakaoSDKCommon
 import FirebaseAuth
 
-final class KakaoAuthManager {
+final class KakaoAuthManager: ThirdPartyAuthProtocol {
     /// 카카오 로그인.  토큰 존재 여부로 기존 로그인 여부 확인.
     func login() {
         if AuthApi.hasToken() {
@@ -19,8 +19,6 @@ final class KakaoAuthManager {
                 if let _ = error {
                     // 토큰 있으나 만료된 토큰이거나, 기타 에러.
                     self.kakaoLogin()
-                } else {
-                    // 토큰 있고 유효하기 때문에 로그인 불필요.
                 }
             }
         } else {
@@ -35,10 +33,10 @@ final class KakaoAuthManager {
         if UserApi.isKakaoTalkLoginAvailable() {
             UserApi.shared.loginWithKakaoTalk { (oAuthToken, error ) in
                 if let error = error {
-                    print(error)
+                    print("카카오톡으로 로그인 실패: \(error)")
                 } else {
                     if let _ = oAuthToken {
-                        print("카카오톡으로 로그인하기 성공~~")
+                        print("카카오톡으로 로그인 성공")
                         self.firebaseLogin()
                     }
                 }
@@ -48,10 +46,10 @@ final class KakaoAuthManager {
         else {
             UserApi.shared.loginWithKakaoAccount { (oAuthToken, error) in
                 if let error = error {
-                    print(error)
+                    print("카카오 계정으로 로그인 실패: \(error)")
                 } else {
                     if let _ = oAuthToken {
-                        print("카카오 계정으로 로그인하기 성공~~")
+                        print("카카오 계정으로 로그인 성공")
                         self.firebaseLogin()
                     }
                 }
@@ -60,7 +58,7 @@ final class KakaoAuthManager {
     }
     
     /// 파이어베이스에 카카오 로그인 아이디, 비번(유저 아이디) 등록
-    private func firebaseLogin() {
+    func firebaseLogin() {
         UserApi.shared.me { (user, error) in
             if let error = error {
                 print(error)
@@ -78,5 +76,13 @@ final class KakaoAuthManager {
                 }
             }
         }
+    }
+    
+    func logout() {
+        
+    }
+    
+    func disconnect() {
+        
     }
 }

--- a/zzimtory/Helper/KakaoAuthManager.swift
+++ b/zzimtory/Helper/KakaoAuthManager.swift
@@ -17,7 +17,7 @@ final class KakaoAuthManager: ThirdPartyAuthProtocol {
         if AuthApi.hasToken() {
             UserApi.shared.accessTokenInfo { userInfo, error in
                 if let _ = error {
-                    // 토큰 있으나 만료된 토큰이거나, 기타 에러.
+                    // 만료된 토큰 or 기타 에러.
                     self.kakaoLogin()
                 }
             }
@@ -68,7 +68,7 @@ final class KakaoAuthManager: ThirdPartyAuthProtocol {
                         if let error = error {
                             print(error)
                             Auth.auth().signIn(withEmail: (user.kakaoAccount?.email)!, password: "\(String(describing: user.id))")
-                            
+                            print("파어에베이스에 로그인 성공")
                         } else {
                             print("파이어베이스에 회원 가입 성공")
                         }
@@ -79,10 +79,22 @@ final class KakaoAuthManager: ThirdPartyAuthProtocol {
     }
     
     func logout() {
-        
+        UserApi.shared.logout { error in
+            if let error = error {
+                print("카카오 로그아웃 실패: \(error)")
+            } else {
+                print("카카오 로그아웃 성공")
+            }
+        }
     }
     
     func disconnect() {
-        
+        UserApi.shared.unlink { error in
+            if let error = error {
+                print("카카오 로그인 연결끊기 실패: \(error)")
+            } else {
+                print("카카오 로그인 연결끊기 성공")
+            }
+        }
     }
 }

--- a/zzimtory/Helper/KakaoAuthManager.swift
+++ b/zzimtory/Helper/KakaoAuthManager.swift
@@ -19,6 +19,8 @@ final class KakaoAuthManager: ThirdPartyAuthProtocol {
                 if let _ = error {
                     // 만료된 토큰 or 기타 에러.
                     self.kakaoLogin()
+                } else {
+                    print("유효한 토큰 존재")
                 }
             }
         } else {

--- a/zzimtory/Helper/NaverAuthManager.swift
+++ b/zzimtory/Helper/NaverAuthManager.swift
@@ -9,7 +9,7 @@ import NaverThirdPartyLogin
 import RxSwift
 import FirebaseAuth
 
-final class NaverAuthManager: NSObject, ThirdPartyAuthProtocol {
+final class NaverAuthManager: NSObject {
     private let instance = NaverThirdPartyLoginConnection.getSharedInstance()
     private let repository: NaverLoginRepositoryProtocol
     private let disposeBag = DisposeBag()
@@ -38,7 +38,9 @@ final class NaverAuthManager: NSObject, ThirdPartyAuthProtocol {
             })
             .disposed(by: disposeBag)
     }
-    
+}
+
+extension NaverAuthManager: ThirdPartyAuthProtocol {
     func login() {
         instance?.requestThirdPartyLogin()
     }

--- a/zzimtory/Helper/NaverAuthManager.swift
+++ b/zzimtory/Helper/NaverAuthManager.swift
@@ -9,17 +9,10 @@ import NaverThirdPartyLogin
 import RxSwift
 import FirebaseAuth
 
-protocol NaverAuthManagerDelegate: AnyObject {
-    func didFinishLogin(id: String, email: String)
-    func didFailLogin(with error: Error)
-}
-
-final class NaverAuthManager: NSObject {
+final class NaverAuthManager: NSObject, ThirdPartyAuthProtocol {
     private let instance = NaverThirdPartyLoginConnection.getSharedInstance()
     private let repository: NaverLoginRepositoryProtocol
     private let disposeBag = DisposeBag()
-    
-    weak var delegate: NaverAuthManagerDelegate?
     
     init(repository: NaverLoginRepositoryProtocol = NaverLoginRepository()) {
         self.repository = repository
@@ -27,64 +20,66 @@ final class NaverAuthManager: NSObject {
         instance?.delegate = self
     }
     
+    private func getUserInfo(completion: @escaping (NaverLoginResponse?) -> Void) {
+        guard let tokenType = instance?.tokenType,
+              let accessToken = instance?.accessToken else {
+            print("토큰 정보가 없습니다.")
+            completion(nil)
+            return
+        }
+        
+        repository.getUserInfo(tokenType: tokenType, accessToken: accessToken)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { response in
+                completion(response)
+            }, onFailure: { error in
+                print("유저 정보 가져오기 실패: \(error)")
+                completion(nil)
+            })
+            .disposed(by: disposeBag)
+    }
+    
     func login() {
         instance?.requestThirdPartyLogin()
+    }
+    
+    func firebaseLogin() {
+        getUserInfo { response in
+            guard let response = response else { return }
+            let email = response.value.email
+            let id = response.value.id
+            let nickname = response.value.nickname
+            
+            Auth.auth().signIn(withEmail: email, password: id) { _, error in
+                if let _ = error {
+                    // 계정이 없는 경우 새로 생성
+                    Auth.auth().createUser(withEmail: email, password: id) { _, createError in
+                        if let createError = createError {
+                            print("Firebase 계정 생성 실패: \(createError.localizedDescription)")
+                        } else {
+                            print("Firebase 계정 생성 성공")
+                        }
+                    }
+                } else {
+                    print("Firebase 로그인 성공")
+                }
+            }
+        }
     }
     
     func logout() {
         instance?.resetToken()
     }
     
-    private func getUserInfo() {
-        guard let isValidToken = instance?.isValidAccessTokenExpireTimeNow(),
-              isValidToken else {
-            print("토큰이 유효하지 않습니다. 로그인이 필요합니다.")
-            return
-        }
-        guard let tokenType = instance?.tokenType,
-              let accessToken = instance?.accessToken else {
-            print("토큰 정보가 없습니다.")
-            return
-        }
-        
-        repository.getUserInfo(tokenType: tokenType, accessToken: accessToken)
-            .observe(on: MainScheduler.instance)
-            .subscribe(onSuccess: { [weak self] response in
-                self?.delegate?.didFinishLogin(
-                    id: response.value.id,
-                    email: response.value.email
-                )
-                self?.firebaseLogin(email: response.value.email, id: response.value.id)
-            }, onFailure: { [weak self] error in
-                self?.delegate?.didFailLogin(with: error)
-            })
-            .disposed(by: disposeBag)
-    }
-    
-    private func firebaseLogin(email: String, id: String) {
-        let password = "NAVER_\(id)"
-        
-        Auth.auth().signIn(withEmail: email, password: password) { _, error in
-            if let _ = error {
-                // 계정이 없는 경우 새로 생성
-                Auth.auth().createUser(withEmail: email, password: password) { _, createError in
-                    if let createError = createError {
-                        print("Firebase 계정 생성 실패: \(createError.localizedDescription)")
-                    } else {
-                        print("Firebase 계정 생성 성공")
-                    }
-                }
-            } else {
-                print("Firebase 로그인 성공")
-            }
-        }
+    func disconnect() {
+        instance?.requestDeleteToken()
     }
 }
 
 extension NaverAuthManager: NaverThirdPartyLoginConnectionDelegate {
     func oauth20ConnectionDidFinishRequestACTokenWithAuthCode() {
         print("네이버 로그인 성공")
-        self.getUserInfo()
+        self.firebaseLogin()
     }
     
     func oauth20ConnectionDidFinishRequestACTokenWithRefreshToken() {
@@ -97,6 +92,5 @@ extension NaverAuthManager: NaverThirdPartyLoginConnectionDelegate {
     
     func oauth20Connection(_ oauthConnection: NaverThirdPartyLoginConnection!, didFailWithError error: (any Error)!) {
         print("에러 : \(error.localizedDescription)")
-        delegate?.didFailLogin(with: error)
     }
 }

--- a/zzimtory/Model/NaverUserModel.swift
+++ b/zzimtory/Model/NaverUserModel.swift
@@ -18,6 +18,7 @@ struct NaverLoginResponse: Decodable {
 }
 
 struct NaverUserInfo: Decodable {
-    let id: String
     let email: String
+    let id: String
+    let nickname: String
 }

--- a/zzimtory/SnsLogin/LoginViewModel.swift
+++ b/zzimtory/SnsLogin/LoginViewModel.swift
@@ -16,7 +16,6 @@ final class LoginViewModel {
     
     init() {
         self.googleAuthManager = GoogleAuthManager()
-        self.googleAuthManager.configure()
         self.naverAuthManager = NaverAuthManager()
         self.naverAuthManager.delegate = self
     }

--- a/zzimtory/SnsLogin/LoginViewModel.swift
+++ b/zzimtory/SnsLogin/LoginViewModel.swift
@@ -17,7 +17,6 @@ final class LoginViewModel {
     init() {
         self.googleAuthManager = GoogleAuthManager()
         self.naverAuthManager = NaverAuthManager()
-        self.naverAuthManager.delegate = self
     }
     
     func signInWithApple() {
@@ -35,16 +34,5 @@ final class LoginViewModel {
     
     func signInWithNaver() {
         naverAuthManager.login()
-    }
-}
-
-extension LoginViewModel: NaverAuthManagerDelegate {
-    func didFinishLogin(id: String, email: String) {
-        print("로그인 성공!")
-        print("이메일: \(email)")
-    }
-    
-    func didFailLogin(with error: Error) {
-        print("로그인 실패: \(error.localizedDescription)")
     }
 }

--- a/zzimtory/SnsLogin/LoginViewModel.swift
+++ b/zzimtory/SnsLogin/LoginViewModel.swift
@@ -11,10 +11,12 @@ import FirebaseAuth
 import GoogleSignIn
 
 final class LoginViewModel {
-    
+    private let googleAuthManager: GoogleAuthManager
     private let naverAuthManager: NaverAuthManager
     
     init() {
+        self.googleAuthManager = GoogleAuthManager()
+        self.googleAuthManager.configure()
         self.naverAuthManager = NaverAuthManager()
         self.naverAuthManager.delegate = self
     }
@@ -24,29 +26,7 @@ final class LoginViewModel {
     }
     
     func signInWithGoogle(on viewContorller: UIViewController) {
-        GoogleAuthManager.shared.login(presenting: viewContorller) { result in    // 나중에 뷰컨 pop하기 위해서 weak self 선언해둠
-            switch result {
-            case .success(let user):
-                print(user)
-                // 로그인 성공 후 로그인 뷰컨 pop
-                guard let idToken = user.idToken?.tokenString else { return }
-                let credential = GoogleAuthProvider.credential(
-                    withIDToken: idToken,
-                    accessToken: user.accessToken.tokenString
-                )
-                Auth.auth().signIn(with: credential) { authResult, error in
-                    if let error = error as NSError? {
-                        print("파이어베이스 인증 오류: \(error.localizedDescription)")
-                        print("에러 코드: \(error.code)")
-                        return
-                    }
-                    print("파이어베이스 인증 성공")
-                }
-            case .failure(let error):
-                print(error)
-                // 사용자 예외 처리 필요
-            }
-        }
+        googleAuthManager.login(from: viewContorller)
     }
     
     func signInWithKakao() {


### PR DESCRIPTION
## 📝 요약(Summary)

- 구글, 애플 로그인을 절차를 `NativeAuthProtocol`로 추상화
- 네이버, 카카오 로그인을 `ThirdPartyAuthProtocol`로 추상화
- 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

![스크린샷 2025-02-01 오전 1 18 16](https://github.com/user-attachments/assets/8c955e73-c53c-4fac-b3a0-298e6308c6b3)

## 💬 공유사항 to 리뷰어

로그인 과정이 플랫폼 별로 너무 뒤죽박죽이라, 파이어베이스에서 로그인을 지원해주는지 그 여부로 나눠서 추상화 해봤습니다!

- 애플, 구글 로그인: 해당 플랫폼 로그인 과정에 파이어베이스 로그인이 포함되어 있음.
- 네이커, 카카오 로그인: 플랫폼 로그인 이후에 파이어베이스 로그인이 필요함.

따라서 추가적인 파이어베이스 로그인 필요 여부로 `NativeAuthProtocol`, `ThirdPartyAuthProtocol`로 나눠서 추상화했습니다!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
