### PR TITLE
[bug] 로그아웃 안되는 오류 해결, 네이버 자동로그인 오류 해결

### DIFF
--- a/zzimtory/Helper/DatabaseManager.swift
+++ b/zzimtory/Helper/DatabaseManager.swift
@@ -30,6 +30,15 @@ final class DatabaseManager {
         return true
     }
     
+    func logout() {
+        do {
+            try Auth.auth().signOut()
+            self.userUID = nil
+        } catch let error as NSError {
+            print("파이어베이스 로그아웃 실패: \(error.localizedDescription)")
+        }
+    }
+    
     private func getUserUID() {
         guard let currentUser = Auth.auth().currentUser else {
             print("현재 인증된 유저가 없습니다.")

--- a/zzimtory/Helper/NaverAuthManager.swift
+++ b/zzimtory/Helper/NaverAuthManager.swift
@@ -86,7 +86,7 @@ extension NaverAuthManager: ThirdPartyAuthProtocol {
     }
     
     func logout() {
-        instance?.resetToken()
+        instance?.requestDeleteToken()
     }
     
     func disconnect() {

--- a/zzimtory/MyPage/MyPageViewController.swift
+++ b/zzimtory/MyPage/MyPageViewController.swift
@@ -128,6 +128,7 @@ extension MyPageViewController: UITableViewDelegate {
             KakaoAuthManager().logout()
             NaverAuthManager().logout()
             AppleAuthManager().logout()
+            DatabaseManager.shared.logout()
             
             let loginVC = LoginViewController()
             navigationController?.pushViewController(loginVC, animated: false)
@@ -136,6 +137,7 @@ extension MyPageViewController: UITableViewDelegate {
             KakaoAuthManager().logout()
             NaverAuthManager().logout()
             AppleAuthManager().logout()
+            DatabaseManager.shared.logout()
             DatabaseManager.shared.deleteUser()
             
             let loginVC = LoginViewController()


### PR DESCRIPTION
## 📝 요약(Summary)

- 로그아웃 후 앱 재실행 시 로그인 상태가 유지되는 버그 해결
  -> 파이어베이스 Auth에서 로그아웃이 안되고 있었음.
- 네이버 로그아웃 후 다시 네이버로 로그인 시 자동로그인이 되는 현상
   -> 로그아웃 시 앱에서 모든 토큰(refresh token, access token)을 삭제하는 게 아니라 access 토큰만 지우고 있었음.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

- DatabaseManager에 파이어베이스 로그아웃 메서드를 만들어서 마이페이지 뷰컨에서 로그아웃이 눌리면 이 메서드가 실행되도록 했습니다!
- 네이버 자동 로그인 문제의 경우, 토큰이 삭제되고 있었던 게 아니라 resetToken이 되고 있었던 게 문제인데요...
  - 토큰에는 Access Token, Refresh Token이 있습니다. 액세스 토큰은 말 그대로 유저 정보에 '접근'할 수 있는 권한이고 리프레시 토큰은 액세스 토큰을 갱신하는 토큰입니다.
  - 그동안 네이버 로그아웃 시 하고 있었던 resetToken은 액세스 토큰만 앱에서 지우고 리프레쉬 토큰은 지우지 않는 메서드입니다. 그래서 다시 로그인을 하면 리프레쉬 토큰을 사용해서 액세스 토큰을 다시 받아와서 자동 로그인이 됐던 것입니다...
  - 네이버 로그아웃 후에는 자동 로그인이 안되게 하고 싶으면 resetToken이 아니라 resquestDeleteToken으로 아예 모든 토큰을 지우면 됩니다!! 그러면 아예 모든 인증과정을 다시 거쳐야하는, 저희가 생각하는 로그아웃 과정이 됩니다!!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
