### PR TITLE
[fix] 검색 화면 버그 수정 완료 closes #114

### DIFF
--- a/zzimtory/Search/View/ItemSearchView/ItemSearchViewController.swift
+++ b/zzimtory/Search/View/ItemSearchView/ItemSearchViewController.swift
@@ -333,7 +333,10 @@ extension ItemSearchViewController {
         output.swipedCard
             .drive(onNext: { [weak self] swipedCard in
                 switch swipedCard.direction {
-                case .right: break
+                case .right:
+                    DatabaseManager.shared.addItemToAggregatePocket(newItem: swipedCard.item) {
+                        return
+                    }
                 case .left: break
                 case .up:
                     guard DatabaseManager.shared.hasUserLoggedIn() else {

--- a/zzimtory/Search/View/ItemSearchView/ItemSearchViewController.swift
+++ b/zzimtory/Search/View/ItemSearchView/ItemSearchViewController.swift
@@ -94,10 +94,12 @@ final class ItemSearchViewController: ZTViewController {
             })
             .disposed(by: disposeBag)
         
-        searchBar.rx.cancelButtonClicked.subscribe(onNext: { [unowned self] in
+        searchBar.rx.cancelButtonClicked
+            .subscribe(onNext: { [unowned self] in
             
             searchBar.becomeFirstResponder()
             view.addSubview(searchHistory)
+            showRecents()
             
         }).disposed(by: disposeBag)
     }
@@ -240,14 +242,14 @@ final class ItemSearchViewController: ZTViewController {
         recentItemsView.isHidden = false
         searchHistory.isHidden = false
         searchHistoryHeader.isHidden = false
+        searchHistory.reloadData()
+        searchHistory.layoutIfNeeded()
     }
     
     private func hideRecents() {
         recentItemsView.isHidden = true
         searchHistory.isHidden = true
         searchHistoryHeader.isHidden = true
-
-        searchHistory.reloadData()
     }
     
     private func hideSearchResults() {

--- a/zzimtory/Search/View/ItemSearchView/ItemSearchViewController.swift
+++ b/zzimtory/Search/View/ItemSearchView/ItemSearchViewController.swift
@@ -226,6 +226,7 @@ final class ItemSearchViewController: ZTViewController {
         self.tabBarController?.tabBar.isHidden = true
         
         view.bringSubviewToFront(cardStack)
+        searchBar.isUserInteractionEnabled = false
     }
     
     private func hideCardStack() {
@@ -235,6 +236,7 @@ final class ItemSearchViewController: ZTViewController {
         self.tabBarController?.tabBar.isHidden = false
         
         view.removeGestureRecognizer(dimLayerTapRecognizer)
+        searchBar.isUserInteractionEnabled = true
     }
     
     // MARK: - CardStack 보이기/숨기기

--- a/zzimtory/Search/ViewModel/ItemSearchViewModel.swift
+++ b/zzimtory/Search/ViewModel/ItemSearchViewModel.swift
@@ -51,7 +51,6 @@ final class ItemSearchViewModel {
         let selectedCard: Driver<Item>
         let swipedCard: Driver<SwipedCard>
         let swipedAllCards: Driver<Void>
-        // let selectedCell: Driver<Item>
         let selectedCell: Driver<([Item], Int)>
         let searchHistory: Driver<[String]>
         let selectedSearchHistory: Driver<String>
@@ -130,13 +129,6 @@ final class ItemSearchViewModel {
         
         let swipedAllCards = input.didSwipeAllCards
             .asDriver(onErrorJustReturn: ())
-        
-//        let selectedCell = input.didSelectItemAt
-//            .withUnretained(self)
-//            .flatMap { viewModel, indexPath -> Observable<Item> in
-//                return viewModel.currentItems.compactMap { $0[indexPath.item] }
-//            }
-//            .asDriver(onErrorDriveWith: .empty())
         
         let selectedCell = input.didSelectItemAt
             .withUnretained(self)

--- a/zzimtory/Search/ViewModel/ItemSearchViewModel.swift
+++ b/zzimtory/Search/ViewModel/ItemSearchViewModel.swift
@@ -20,24 +20,20 @@ final class ItemSearchViewModel {
     private let recentItemsRelay = BehaviorRelay<[Item]>(value: []) // 최근 아이템 Relay 적용
     var recentItems: Observable<[Item]> { return recentItemsRelay.asObservable() }
     
+    private let searchHistoryKey = "searchHistory"
+    private let searchHistoryRelay = BehaviorRelay<[String]>(value: [])
     private var currentItems = BehaviorRelay<[Item]>(value: [])
-    private var searchHistory = UserDefaults.standard.array(forKey: "searchHistory") as? [String] ?? [] {
-        didSet {
-            // 10개 이상일 경우 초과되는 기록 제거
-            if searchHistory.count > 10 {
-                searchHistory.removeSubrange(10..<searchHistory.count)
-            }
-            
-            searchHistory = searchHistory.filter { !$0.isEmpty }
-            UserDefaults.standard.set(searchHistory, forKey: "searchHistory")
-        }
-    }
     
     // MARK: - 무한 스크롤 프로퍼티
     private var currentPage = 1     // 현재 페이지
     private(set) var isLoading = false   // 로딩중인지 체크
     private(set) var hasMoreData = true  // 더 가져올 데이터가 있는지 체크
     private let itemsPerPage = 10   // request당 가져올 데이터 개수
+    
+    init() {
+        let searchHistory = userDefaults.array(forKey: searchHistoryKey) as? [String] ?? []
+        searchHistoryRelay.accept(searchHistory)
+    }
     
     struct Input {
         var query: Observable<String>
@@ -73,7 +69,8 @@ final class ItemSearchViewModel {
             .withUnretained(self)
             .flatMap { viewModel, indexPath -> Observable<String> in
                 print("tapped \(indexPath.item)")
-                let selectedHistory = viewModel.searchHistory[indexPath.item]
+                let searchHistory = viewModel.searchHistoryRelay.value
+                let selectedHistory = searchHistory[indexPath.item]
                 return Observable.just(selectedHistory)
             }
             .share()
@@ -90,11 +87,13 @@ final class ItemSearchViewModel {
                 viewModel.currentPage = 1
                 viewModel.hasMoreData = true
                 
-                if viewModel.searchHistory.contains(query) {
-                    viewModel.searchHistory.removeAll(where: { $0 == query })
+                var searchHistory = viewModel.searchHistoryRelay.value
+                
+                if searchHistory.contains(query) {
+                    searchHistory.removeAll(where: { $0 == query })
                 }
                 
-                viewModel.searchHistory.insert(query, at: 0)
+                searchHistory.insert(query, at: 0)
                 
                 let fetchedItems = viewModel.shoppingRepository.fetchForViewModel(with: query)
                 // 불러온 아이템들 추가
@@ -148,32 +147,47 @@ final class ItemSearchViewModel {
             .asDriver(onErrorDriveWith: .empty())
         
         // MARK: - 검색 기록
-        let searchHistoryRemoved = input.didRemoveItemAt
-            .withUnretained(self)
-            .flatMap { viewModel, indexPath -> Observable<[String]> in
-                viewModel.searchHistory.remove(at: indexPath.item)
-                return Observable.just(viewModel.searchHistory)
-            }
+        let _ = query.subscribe(onNext: { [weak self] query in
+            let searchHistory = self?.searchHistoryRelay.value.filter { $0 != query }
+            
+            let updatedSearchHistory: [String] = [query] + (searchHistory ?? [])
+            
+            self?.searchHistoryRelay.accept(updatedSearchHistory)
+        })
         
-        let searchHistoryCleared = input.didTapClearHistory
-            .withUnretained(self)
-            .flatMap { viewModel, _ -> Observable<[String]> in
-                viewModel.searchHistory.removeAll()
-                return Observable.just(viewModel.searchHistory)
-            }
+        let _ = input.didRemoveItemAt.subscribe(onNext: { [weak self] index in
+            var searchHistory = self?.searchHistoryRelay.value ?? []
+            
+            searchHistory.remove(at: index.item)
+            
+            self?.searchHistoryRelay.accept(searchHistory)
+        })
         
-        let searchHistory = Observable.merge(
-            Observable.just(searchHistory),
-            searchHistoryRemoved,
-            searchHistoryCleared
-        )
+        let _ = input.didTapClearHistory.subscribe(onNext: { [weak self] in
+            self?.searchHistoryRelay.accept([])
+        }).disposed(by: disposeBag)
+        
+        let searchHistory = searchHistoryRelay.asDriver(onErrorDriveWith: .empty())
+        
+        searchHistoryRelay.bind { [weak self] history in
+            var updatedSearchHistory = history
+            
+            if updatedSearchHistory.count > 10 {
+                updatedSearchHistory.removeSubrange(10..<history.count)
+                self?.searchHistoryRelay.accept(updatedSearchHistory)
+            }
+            
+            updatedSearchHistory = updatedSearchHistory.filter { !$0.isEmpty }
+            self?.userDefaults.set(updatedSearchHistory, forKey: self?.searchHistoryKey ?? "searchHistory")
+
+        }.disposed(by: disposeBag)
         
         let output = Output(searchResult: searchResult,
                             selectedCard: selectedCard,
                             swipedCard: swipedCard,
                             swipedAllCards: swipedAllCards,
                             selectedCell: selectedCell,
-                            searchHistory: searchHistory.asDriver(onErrorDriveWith: .empty()),
+                            searchHistory: searchHistory,
                             selectedSearchHistory: selectedSearchHistory.asDriver(onErrorDriveWith: .empty())
         )
         


### PR DESCRIPTION
## 📝 요약(Summary)

검색화면에 있던 버그들을 수정했습니다.
1. 검색결과 무한 스크롤 시 CardStack이 반복적으로 나오는 버그
2. 무한 스크롤 시 들어갔던 상세페이지 혹은 아이템 추가 모달창 나타나는 버그
3. 검색기록이 실시간으로 반영되지 않는 버그
4. dimLayer가 있을 때 searchBar가 선택되는 버그
5. cardStack에서 오른쪽스와이프하여 전체보기 주머니에 추가하는 기능 구현


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
